### PR TITLE
UTF-8 and Windows-1252 Checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,21 +172,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "encoding_rs_io"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
-dependencies = [
- "encoding_rs",
 ]
 
 [[package]]
@@ -606,8 +661,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "diff_match_patch",
- "encoding_rs",
- "encoding_rs_io",
+ "encoding",
  "gio",
  "gtk",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ zip = "0.5"
 clap = {version = "2", optional = true}
 serde = {version = "1.0", features = ["derive"]}
 regex = "1"
-encoding_rs = "0.8"
-encoding_rs_io = "0.1"
+encoding = "0.2"
 diff_match_patch = "0.1"
 
 

--- a/src/bin/merger-cli.rs
+++ b/src/bin/merger-cli.rs
@@ -1,6 +1,8 @@
-use paradoxmerger::{parse_args,parse_configs,ModInfo,ModPack,generate_mod_list,files_in_vanilla,extract_all_files,auto_merge,write_mod_desc_to_folder};
+use paradoxmerger::{parse_configs,ModInfo,ModPack,generate_mod_list,files_in_vanilla,extract_all_files,auto_merge,write_mod_desc_to_folder,ArgOptions};
 
-use std::path::Path;
+use std::path::{PathBuf,Path};
+use clap::{Arg,App};
+
 
 fn main() {
     let args = parse_args();
@@ -40,4 +42,49 @@ fn main() {
         Err(e) => {eprintln!("{}",e);}
     }
         
+}
+
+pub fn parse_args() -> ArgOptions {
+    let args = App::new("Parker's Paradox Patcher")
+    .version("0.2")
+    .about("Merges some mods together automatically sometimes.")
+    .author("Parker Okonek")
+    .arg(Arg::with_name("config")
+    .short("c")
+    .long("config")
+    .value_name("CONFIG_FILE")
+    .help("configuration file to load, defaults to current directory")
+    .takes_value(true))
+    .arg(Arg::with_name("extract")
+    .short("x")
+    .long("extract")
+    .help("extract all non-conflicting files to a folder"))
+    .arg(Arg::with_name("dry-run")
+    .short("d")
+    .long("dry-run")
+    .help("list file conflicts without merging"))
+    .arg(Arg::with_name("verbose")
+    .short("v")
+    .long("verbose")
+    .help("print information about processed mods"))
+    .arg(Arg::with_name("game_id")
+    .required(false)
+    .index(2)
+    .help("game in the config to use"))
+    .arg(Arg::with_name("patch_name")
+    .index(1)
+    .required(true)
+    .help("name of the generated mod"))
+    .get_matches();
+    
+    
+    let mut config_path = PathBuf::new();
+    config_path.push(args.value_of("config").unwrap_or("./merger.toml"));
+    let extract = args.is_present("extract");
+    let dry_run = args.is_present("dry-run");
+    let verbose = args.is_present("verbose");
+    let game_id = String::from(args.value_of("game_id").unwrap_or(""));
+    let patch_name: String = String::from(args.value_of("patch_name").unwrap_or("merged_patch"));
+    
+    ArgOptions::new(config_path,extract,dry_run,verbose,game_id,patch_name)
 }

--- a/src/text_encoding.rs
+++ b/src/text_encoding.rs
@@ -1,0 +1,19 @@
+use encoding::{Encoding, DecoderTrap};
+use encoding::all::WINDOWS_1252;
+
+fn decode_latin1(input: &[u8]) -> Option<String> {
+    match WINDOWS_1252.decode(input,DecoderTrap::Strict) {
+        Ok(s) => Some(s),
+        _ => None,
+    }
+}
+pub fn encode_latin1(input: &[u8]) -> String {
+    String::new()
+}
+
+pub fn read_utf8_or_latin1(input: Vec<u8>) -> Option<String> {
+    match String::from_utf8(input.clone()) {
+        Err(_e) => decode_latin1(&input),
+        Ok(s) => Some(s),
+    }
+}

--- a/src/text_encoding.rs
+++ b/src/text_encoding.rs
@@ -1,4 +1,4 @@
-use encoding::{Encoding, DecoderTrap};
+use encoding::{Encoding, DecoderTrap, EncoderTrap};
 use encoding::all::WINDOWS_1252;
 
 fn decode_latin1(input: &[u8]) -> Option<String> {
@@ -7,8 +7,11 @@ fn decode_latin1(input: &[u8]) -> Option<String> {
         _ => None,
     }
 }
-pub fn encode_latin1(input: &[u8]) -> String {
-    String::new()
+pub fn encode_latin1(input: String) -> Option<Vec<u8>> {
+    match WINDOWS_1252.encode(&input, EncoderTrap::Strict) {
+        Ok(s) => Some(s),
+        Err(_e) => None,
+    }
 }
 
 pub fn read_utf8_or_latin1(input: Vec<u8>) -> Option<String> {


### PR DESCRIPTION
Now the parser will try to read files as UTF-8, if this fails then the file is decoded from Windows-1252 into a string. If both these conversions fail, then the file is not read. Fixes #2 and tries its best to output files back into Windows-1252, the expected encoding for CK2. 